### PR TITLE
Add edition IDs for win10S and win10SN

### DIFF
--- a/convert.sh
+++ b/convert.sh
@@ -16,6 +16,8 @@ fi
 
 editions='analogonecore
 andromeda
+cloud
+cloudn
 cloude
 clouden
 core


### PR DESCRIPTION
Hi!
Recently I tried to use the converter to generate ISOs for edition `Windows 10 S` and `Windows 10 S N`. It seems that the following edition IDs should be added:

```
Cloud = Windows 10 S
CloudN = Windows 10 S N
```

Otherwise, I will get a `No metadata ESDs found.` error when executing the script.

Reference: [User:Cvolton/user/List of Windows 10 editions](https://betawiki.net/index.php?title=User:Cvolton/user/List_of_Windows_10_editions&mobileaction=toggle_view_desktop)