### PR TITLE
v0.6.2

### DIFF
--- a/convert_ve_plugin
+++ b/convert_ve_plugin
@@ -1425,7 +1425,10 @@ function createVirtualEdition() {
 
   wimlib-imagex info ISODIR/sources/install.$type "$newName" \
     --image-property DESCRIPTION="$description" \
-    --image-property WINDOWS/EDITIONID=$edition
+    --image-property DISPLAYNAME="$description" \
+    --image-property DISPLAYDESCRIPTION="$description" \
+    --image-property WINDOWS/EDITIONID=$edition \
+    --image-property FLAGS=$edition
 
   if [ $? != 0 ]; then
     echo "Failed to update information for $edition."


### PR DESCRIPTION
Update bootSourcesList for build 20231 and later
Add PPIPro to editions list
Skip extracting/converting updates "windows10.0-kb*.cab"
Skip rebuilding install.wim/.esd if no VirtualEditions added
Set image-property FLAGS for each index
Create UEFI-only iso for arm64 builds