### PR TITLE
Add descriptions for ArchLinux dependencies

### DIFF
--- a/convert.sh
+++ b/convert.sh
@@ -308,6 +308,9 @@ if ! which cabextract >/dev/null 2>&1 \
     # Linux
     echo "If you use Debian or Ubuntu you can install these using:"
     echo "sudo apt-get install cabextract wimtools chntpw genisoimage"
+    echo ""
+    echo "If you use Arch Linux you can install these using:"
+    echo "sudo pacman -S cabextract wimlib chntpw cdrtools"
   elif [ `uname` == "Darwin" ]; then
     # macOS
     echo "macOS requires Homebrew (https://brew.sh) to install the prerequisite software."

--- a/readme.md
+++ b/readme.md
@@ -76,6 +76,11 @@ using the following command:
 sudo apt-get install cabextract wimtools chntpw genisoimage
 ```
 
+If you use Arch Linux you can also install these using the following command:
+```bash
+sudo pacman -S cabextract wimlib chntpw cdrtools
+```
+
 If you use any other distribution, then you will need to check its repository
 for packages needed to run this script.
 


### PR DESCRIPTION
``` patch
diff --git a/convert.sh b/convert.sh
index b28ffca..9dbc6c9 100755
--- a/convert.sh
+++ b/convert.sh
@@ -308,6 +308,9 @@ if ! which cabextract >/dev/null 2>&1 \
     # Linux
     echo "If you use Debian or Ubuntu you can install these using:"
     echo "sudo apt-get install cabextract wimtools chntpw genisoimage"
+    echo ""
+    echo "If you use Arch Linux you can install these using:"
+    echo "sudo pacman -S cabextract wimlib chntpw cdrtools"
   elif [ `uname` == "Darwin" ]; then
     # macOS
     echo "macOS requires Homebrew (https://brew.sh) to install the prerequisite software."
diff --git a/readme.md b/readme.md
index 9361096..4678910 100644
--- a/readme.md
+++ b/readme.md
@@ -76,6 +76,11 @@ using the following command:
 sudo apt-get install cabextract wimtools chntpw genisoimage
_```
 
+If you use Arch Linux you can also install these using the following command:
+```bash
+sudo pacman -S cabextract wimlib chntpw cdrtools
+```
+
 If you use any other distribution, then you will need to check its repository
 for packages needed to run this script.
 
```